### PR TITLE
Restart Service Monitor Service on deployment

### DIFF
--- a/content/newrelic.cmd
+++ b/content/newrelic.cmd
@@ -80,6 +80,9 @@ GOTO:EOF
 	  REM  The New Relic Server Monitor installed ok and does not need to be installed again.
 	  ECHO New Relic Server Monitor was installed successfully. >> "%RoleRoot%\nr_server.log" 2>&1
 
+	  NET STOP "New Relic Server Monitor Service"
+	  NET START "New Relic Server Monitor Service"
+
 	) ELSE (
 	  REM   An error occurred. Log the error to a separate log and exit with the error code.
 	  ECHO  An error occurred installing the New Relic Server Monitor 1. Errorlevel = %ERRORLEVEL%. >> "%RoleRoot%\nr_server_error.log" 2>&1


### PR DESCRIPTION
I've noticed that on occasion the New Relic Server Monitor service stops running after a deployment. While the upgrade to a new version is successful, I have to remote into the cloud service and start the service manually. This can be a frustrating experience, especially if I don't have remote desktop enabled for the cloud service.

This pull request restarts the service automatically. I tested this on a couple different cloud services where the Server Monitor was no longer running and it successfully brought the monitor back up.
