### PR TITLE
Prepend child issue

### DIFF
--- a/NewRelicWindowsAzure.nuspec
+++ b/NewRelicWindowsAzure.nuspec
@@ -5,8 +5,8 @@
     <version>4.1.136.0</version>
     <title>New Relic x64 for Windows Azure</title>
     <authors>Mike Cousins,Nick Floyd</authors>
-    <licenseUrl>http://newrelic.com</licenseUrl>
-    <projectUrl>http://www.mikecousins.com/new-relic-windows-azure-package-for-nuget</projectUrl>
+    <licenseUrl>http://newrelic.com/terms</licenseUrl>
+    <projectUrl>https://github.com/newrelic/nuget-azure-cloud-services</projectUrl>
     <iconUrl>http://newrelic.com/images/avatar-newrelic.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Make sure you go to New Relic first to sign up and get your key at http://newrelic.com. Performance monitoring will never be the same after you do!  


### PR DESCRIPTION
Fixes an issue where when the ConfigurationSettings element is empty (i.e. it contains no children) the powershell will convert the selection of the node to a system.string.  Also addresses an issue where if elements from either the ServiceConfiguration files or the ServiceDefinition file return null an exception would be thrown and installation would be incomplete.

**Issues in more detail**

1. If the ConfigurationSettings element is empty (i.e. it contains no children) the powershell will convert the selection of the node to a system.string. 

So given: 

```
<?xml version="1.0" encoding="utf-8"?> 
<ServiceConfiguration serviceName="Ticket136538_CloudB" xmlns="http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceConfiguration" osFamily="3" osVersion="*" schemaVersion="2014-06.2.4"> 
  <Role name="WCFServiceWebRole1"> 
    <Instances count="1" /> 
    <ConfigurationSettings> 
    </ConfigurationSettings> 
  </Role> 
</ServiceConfiguration> 
```

An error will be thrown because the script: $modifiedConfigSettings = $modified.ConfigurationSettings will see ConfigurationSettings as a string not an xml node. Later when the script tries to append the new license key node: $modifiedConfigSettings.AppendChild($settingNode) it throws: 
Method invocation failed because [System.String] does not contain a method named 'AppendChild'. 

The code has been changed to us xpath and namespacing: 
```
$ns = new-object Xml.XmlNamespaceManager $xml.NameTable 
$ns.AddNamespace('dns', 'http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceConfiguration&#39;) 
$modifiedConfigSettings = $modified.SelectSingleNode("/dns:ServiceConfiguration/dns:Role/dns:ConfigurationSettings", $ns) 
```

2. This error was being masked by a null exception where the local $modified (the xml node that will be manipulated) was never being set but still trying to be used later in the script. 