### PR TITLE
updates the cmd file so that if the environment is currently being emulated then we do not install the agent or WSM

### DIFF
--- a/content/newrelic.cmd
+++ b/content/newrelic.cmd
@@ -1,5 +1,8 @@
 SETLOCAL EnableExtensions
 
+:: Bypass installing the agent and server monitor if locally emulating
+IF "%EMULATED%" EQU "true" GOTO:EOF
+
 for /F "usebackq tokens=1,2 delims==" %%i in (`wmic os get LocalDateTime /VALUE 2^>NUL`) do if '.%%i.'=='.LocalDateTime.' set ldt=%%j
 set ldt=%ldt:~0,4%-%ldt:~4,2%-%ldt:~6,2% %ldt:~8,2%:%ldt:~10,2%:%ldt:~12,6%
 
@@ -36,7 +39,7 @@ IF %NR_ERROR_LEVEL% EQU 0 (
 	:: WEB ROLES : Restart the service to pick up the new environment variables
 	:: 	if we are in a Worker Role then there is no need to restart W3SVC _or_
 	:: 	if we are emulating locally then do not restart W3SVC
-	IF "%IsWorkerRole%" EQU "false" IF "%EMULATED%" EQU "false" (
+	IF "%IsWorkerRole%" EQU "false" (
 		ECHO Restarting IIS and W3SVC to pick up the new environment variables >> "%RoleRoot%\nr.log" 2>&1
 		IISRESET
 		NET START W3SVC


### PR DESCRIPTION
#### Synopsis

If you start an Azure Cloud Service locally in the Compute Emulator while the New Relic .NET NuGet package is installed, the role won't start. 

To reproduce: 

1. Create a Cloud Service in Visual Studio from a template like ASP.NET Web Role > MVC. 

2. Install the NuGet package: install-package newrelicwindowsazure 

3. Choose Start Debugging from the Tools menu. 

The Compute Emulator will start and you'll get a Windows Installer prompt and/or a warning that the role is taking a long time to start. The Windows Installer prompt continues to prompt in a loop. Clicking Yes on the warning dialog doesn't have an effect on the loop. 

#### Key changes

This change will cause the script to noop if it detects emulation

#### User visible effects

Users who use the compute emulator will now be able to start the emulator up without side effects from the New Relic nuget package

#### Sidekick

@enelson-newrelic
